### PR TITLE
Add default log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo build --release --all-features
 ### 🏁 Quickstart
 
 ```shell
-env RUST_LOG=info ./target/release/sigop-cli -s "myFunction(address)"
+./target/release/sigop-cli -s "myFunction(address)"
 ```
 
 Which should print:

--- a/sigop-cli/src/main.rs
+++ b/sigop-cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
-use log::{info, warn};
+use env_logger::Builder;
+use log::{info, warn, LevelFilter};
 use sigop_core::optimizer::run;
 
 #[derive(Parser)]
@@ -19,7 +20,11 @@ struct Cli {
 }
 
 fn main() {
-    env_logger::init();
+    let mut builder = Builder::new();
+
+    builder.filter_level(LevelFilter::Info);
+    builder.parse_default_env();
+    builder.init();
 
     let cli = Cli::parse();
     let optimized = run(&cli.signature, cli.level, cli.target);


### PR DESCRIPTION
## Description

This PR adds a default log level to the internal logger.
It is set to default but can be overwritten by setting the `RUST_LOG` env. variable.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
